### PR TITLE
fix: index: wabt returns Promise

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const wabt = require('wabt')();
+const createWabt = require('wabt');
 const util = require('util');
 
 getDecoderEncoder = () => {
@@ -14,6 +14,7 @@ getDecoderEncoder = () => {
 }
 
 module.exports = async (input, importObject) => {
+  const wabt = await createWabt(); 
   const { Decoder, Encoder } = getDecoderEncoder();
   const wasmModule = wabt.parseWat('inline', new Encoder('utf-8').encode(input));
   const { buffer } = wasmModule.toBinary({});


### PR DESCRIPTION
Fixed crash:

```js
/Users/coderaiser/webasm/node_modules/wabt/index.js:9
var Module=typeof WabtModule!="undefined"?WabtModule:{};var readyPromiseResolve,readyPromiseReject;Module["ready"]=new Promise(function(resolve,reject){readyPromiseResolve=resolve;readyPromiseReject=reject});var moduleOverrides=Object.ass(


TypeError: wabt.parseWat is not a function
    at module.exports (/Users/coderaiser/webasm/node_modules/inline-webassembly/lib/index.js:18:27)
    at Object.<anonymous> (/Users/coderaiser/webasm/index.js:4:1)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
  1 const once = require('once');¬
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
```

[once](https://www.npmjs.com/package/once) can be used to avoid additional create every time.

And now got an error:

```
Error: parseWat failed:
inline:4:7: error: unexpected token get_local, expected ).
      get_local $n1
      ^^^^^^^^^
inline:5:7: error: unexpected token get_local.
      get_local $n2
      ^^^^^^^^^

    at Object.parseWat (/Users/coderaiser/webasm/node_modules/wabt/index.js:28:27363)
    at module.exports (/Users/coderaiser/webasm/node_modules/inline-webassembly/lib/index.js:20:27)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

When I use example:

```js
const iw = require('inline-webassembly');

iw(`
  (module
    (func (export "add") (param $n1 i32) (param $n2 i32) (result i32)
      get_local $n1
      get_local $n2
      i32.add))`
).then((wasmModule) => {
  const sum = wasmModule.add(44, 99);
  console.log(`Sum = ${sum}`); // 143
});
```

Could you please help me :)?